### PR TITLE
[feature]Cloud Run関数用のDockerfileを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Python 3.12をベースイメージとして使用
+FROM python:3.12-slim
+
+# 作業ディレクトリを設定
+WORKDIR /app
+
+# FFmpegをインストール（動画処理に必要）
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ffmpeg && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# 依存関係ファイルをコピー
+COPY requirements.txt .
+
+# 依存関係をインストール
+RUN pip install --no-cache-dir -r requirements.txt
+
+# ソースコードをコピー
+COPY main.py .
+
+# Cloud Run関数のエントリポイントを設定
+CMD ["python", "main.py"]
+
+# Cloud Run関数のエントリポイントとして関数名を環境変数で指定
+ENV FUNCTION_TARGET=process_video


### PR DESCRIPTION
# Cloud Run関数用のDockerfileを追加

## 変更内容
- Cloud Run関数のPython 3.12実行環境のためのDockerfileを新規作成
- FFmpegを含めて動画処理に必要なライブラリを導入
- 依存関係のインストールと設定
- エントリポイントの指定（process_video関数）

## 変更理由
- Cloud Run関数でPythonコードを実行するためにはDockerfileが必要
- 動画を音声に変換するために必要なFFmpegの導入
- デプロイ環境の一貫性を確保するため

## 注意点
- ベースイメージとしてpython:3.12-slimを使用（要件に合わせて）
- FFmpegは必要最小限のインストールを行い、コンテナサイズを最適化
